### PR TITLE
Prepare for upcoming change to File.openRead()

### DIFF
--- a/lib/src/data_frame/csv_data_frame.dart
+++ b/lib/src/data_frame/csv_data_frame.dart
@@ -184,6 +184,7 @@ class CsvDataFrame implements DataFrame {
 
   Future<List<List<dynamic>>> _extractData() =>
       _file.openRead()
+        .cast<List<int>>()
         .transform(utf8.decoder)
         .transform(_csvCodec.decoder)
         .toList();

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: ml_preprocessing
 description: Implementaion of popular algorithms of data preprocessing for machine learning
-version: 3.4.0
+version: 3.4.0+1
 author: Ilia Gyrdymov <ilgyrd@gmail.com>
 homepage: https://github.com/gyrdym/ml_preprocessing
 


### PR DESCRIPTION
An upcoming change to the Dart SDK will change the signature
of `File.openRead()` from returning `Stream<List<int>>` to
returning `Stream<Uint8List>`.

This forwards-compatible change prepares for that SDK breaking
change by casting the Stream to `List<int>` before transforming
it.

https://github.com/dart-lang/sdk/issues/36900